### PR TITLE
fix: 修复 Cookie 解析中 Base64 token 被截断的问题

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -278,8 +278,12 @@ async function checkAuth(request, kv) {
   
   const cookies = Object.fromEntries(
     cookieHeader.split(';').map(cookie => {
-      const [key, value] = cookie.trim().split('=')
-      return [key, value]
+      const trimmed = cookie.trim()
+      const index = trimmed.indexOf('=')
+      if(index > 0){
+        return [trimmed.substring(0, index), trimmed.substring(index + 1)]
+      }
+      return ['', ''] 
     })
   )
   


### PR DESCRIPTION
https://github.com/IonRh/HomePage/issues/3

修复 Cookie 解析中 Base64 token 被截断的问题